### PR TITLE
Make Marty.register take options and pass them down to the class it is registering

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -42,8 +42,8 @@ class Container {
     return _.values(this.defaults[type]);
   }
 
-  register(clazz) {
-    var defaultInstance = new clazz({});
+  register(clazz, options) {
+    var defaultInstance = new clazz(options || {});
     var type = classType(defaultInstance);
 
     if (!this.types[type]) {

--- a/lib/create.js
+++ b/lib/create.js
@@ -18,8 +18,9 @@ module.exports = {
   createActionCreators: createActionCreators
 };
 
-function register(id, clazz) {
+function register(id, clazz, options) {
   if (!_.isString(id)) {
+    options = clazz;
     clazz = id;
     id = null;
   }
@@ -34,7 +35,7 @@ function register(id, clazz) {
     clazz.displayName = clazz.id;
   }
 
-  return this.container.register(clazz);
+  return this.container.register(clazz, options);
 }
 
 function createContext(req) {

--- a/test/browser/registerSpec.js
+++ b/test/browser/registerSpec.js
@@ -11,6 +11,21 @@ describe('Marty#register', function () {
   describe('Store', function () {
     var ExpectedStore, ActualStore, expectedInitialState;
 
+    describe('when you pass options', function () {
+      it('should take them', function () {
+        class ExpectedStore extends Marty.Store {
+          constructor(options) {
+            super(options);
+            this.state = {};
+            this.options = options;
+          }
+        };
+        let expectedOptions = {some: 'options'}
+        ActualStore = Marty.register(ExpectedStore, expectedOptions)
+        expect(ActualStore.options).to.eql(expectedOptions)
+      });
+    });
+
     describe('when you dont pass in an id', function () {
       beforeEach(function () {
         expectedInitialState = {


### PR DESCRIPTION
Make `Marty.register` take options and pass them down to the class it is registering.

You have no other way of passing options to registered stores otherwise :( (unless that is intended to be like that?).

Couldn't run the browser tests though :( keep on getting this messages:

```
marty [register-options] $ make test-browser
Mock server running at http://localhost:8956
INFO [karma]: Karma v0.12.31 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
(node) warning: possible EventEmitter memory leak detected. 11 bundled listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Browserify.addListener (events.js:236:17)
    at Browserify.once (events.js:262:8)
    at deferredBundle (/Users/daris/UXtemple/opensource/dariocravero/marty/node_modules/karma-bro/lib/bro.js:183:11)
    at Browserify.w.bundleFile (/Users/daris/UXtemple/opensource/dariocravero/marty/node_modules/karma-bro/lib/bro.js:243:7)
    at /Users/daris/UXtemple/opensource/dariocravero/marty/node_modules/karma-bro/lib/bro.js:269:9
    at nextPreprocessor (/Users/daris/UXtemple/opensource/dariocravero/marty/node_modules/karma/lib/preprocessor.js:59:28)
    at /Users/daris/UXtemple/opensource/dariocravero/marty/node_modules/karma/lib/preprocessor.js:97:7
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:379:3)
INFO [Chrome 41.0.2272 (Mac OS X 10.10.2)]: Connected on socket pH-v6pTdvghlB0aux4xP with id 5424164
WARN [Chrome 41.0.2272 (Mac OS X 10.10.2)]: Disconnected (1 times), because no message in 10000 ms.

Chrome 41.0.2272 (Mac OS X 10.10.2): Executed 0 of 0 DISCONNECTED (10.872 secs / 0 secs)
```