### PR TITLE
:memo: Better pattern for query error handling

### DIFF
--- a/docs/_guides/fetching-state/index.md
+++ b/docs/_guides/fetching-state/index.md
@@ -75,11 +75,14 @@ var UserQueries = Marty.createQueries({
   getUser: function (userId) {
     this.dispatch(UserConstants.RECEIVE_USER_STARTING, userId);
 
-    return UserAPI.getUser(userId).then(function (res) {
-      this.dispatch(UserConstants.RECEIVE_USER, userId, res.body);
-    }.bind(this)).catch(function (err) {
-      this.dispatch(UserConstants.RECEIVE_USER_FAILED, userId, err);
-    }.bind(this));
+    return UserAPI.getUser(userId).then(
+      function (res) {
+        this.dispatch(UserConstants.RECEIVE_USER, userId, res.body);
+      }.bind(this)),
+      function (err) {
+        this.dispatch(UserConstants.RECEIVE_USER_FAILED, userId, err);
+      }.bind(this)
+    );
   }
 });
 
@@ -128,8 +131,10 @@ class UserQueries extends Marty.Queries {
     this.dispatch(UserConstants.RECEIVE_USER_STARTING, userId);
 
     return userAPI.getUser(userId)
-      .then(res => this.dispatch(UserConstants.RECEIVE_USER, userId, res.body))
-      .catch(err => this.dispatch(UserConstants.RECEIVE_USER_FAILED, userId, err));
+      .then(
+        res => this.dispatch(UserConstants.RECEIVE_USER, userId, res.body),
+        err => this.dispatch(UserConstants.RECEIVE_USER_FAILED, userId, err)
+      );
   }
 }
 

--- a/docs/_guides/queries/index.md
+++ b/docs/_guides/queries/index.md
@@ -14,15 +14,18 @@ var UserQueries = Marty.createQueries({
   id: 'UserQueries',
   getUser: function (id) {
     this.dispatch(UserConstants.RECEIVE_USER_STARTING, id);
-    UserAPI.getUser(id).then(function (res) {
-      if (res.status === 200) {
-        this.dispatch(UserConstants.RECEIVE_USER, res.body, id);
-      } else {
-        this.dispatch(UserConstants.RECEIVE_USER_FAILED, id);
-      }
-    }.bind(this)).catch(function (err) {
-      this.dispatch(UserConstants.RECEIVE_USER_FAILED, id, err);
-    }.bind(this))
+    UserAPI.getUser(id).then(
+      function (res) {
+        if (res.status === 200) {
+          this.dispatch(UserConstants.RECEIVE_USER, res.body, id);
+        } else {
+          this.dispatch(UserConstants.RECEIVE_USER_FAILED, id);
+        }
+      }.bind(this),
+      function (err) {
+        this.dispatch(UserConstants.RECEIVE_USER_FAILED, id, err);
+      }.bind(this)
+    );
   }
 });
 
@@ -31,13 +34,16 @@ es6
 class UserQueries extends Marty.Queries {
   getUser(id) {
     this.dispatch(UserConstants.RECEIVE_USER_STARTING, id);
-    UserAPI.getUser(id).then((res) => {
-      if (res.status === 200) {
-        this.dispatch(UserConstants.RECEIVE_USER, res.body, id);
-      } else {
-        this.dispatch(UserConstants.RECEIVE_USER_FAILED, id);
-      }
-    }).catch((err) => this.dispatch(UserConstants.RECEIVE_USER_FAILED, id, err));
+    UserAPI.getUser(id).then(
+      res => {
+        if (res.status === 200) {
+          this.dispatch(UserConstants.RECEIVE_USER, res.body, id);
+        } else {
+          this.dispatch(UserConstants.RECEIVE_USER_FAILED, id);
+        }
+      },
+      err => this.dispatch(UserConstants.RECEIVE_USER_FAILED, id, err)
+    );
   }
 }
 


### PR DESCRIPTION
The then/catch pattern used previously will also catch errors in listeners to the RECEIVE_USER action. This leads to weird things like exceptions in component rendering triggered by a successful user receive to be swallowed.