### PR TITLE
Pass finished fetch results into `pending`

### DIFF
--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -74,8 +74,9 @@ function createContainer(InnerComponent, config) {
     },
     render() {
       var container = this;
+      var result = this.state.result;
 
-      return this.state.result.when({
+      return result.when({
         done(results) {
           if (_.isFunction(container.done)) {
             return container.done(results);
@@ -85,7 +86,7 @@ function createContainer(InnerComponent, config) {
         },
         pending() {
           if (_.isFunction(container.pending)) {
-            return container.pending();
+            return container.pending(result.result);
           }
 
           return <div></div>;

--- a/lib/createContainer/getFetchResult.js
+++ b/lib/createContainer/getFetchResult.js
@@ -25,7 +25,9 @@ function getFetchResult(component) {
   }
 
   if (isPending) {
-    return fetch.pending();
+    return _.extend(fetch.pending(), {
+      result: results
+    });
   }
 
   return fetch.done(results);

--- a/test/browser/containerSpec.js
+++ b/test/browser/containerSpec.js
@@ -482,6 +482,9 @@ describe('Container', function () {
           },
           bar() {
             return fetch.pending();
+          },
+          baz() {
+            return fetch.done('bam');
           }
         },
         pending: handler
@@ -490,6 +493,13 @@ describe('Container', function () {
 
     it('should call the handler with the fetches and component', function () {
       expect(handler).to.be.calledOnce;
+    });
+
+    it('should pass in all the fetch results that have finished', function () {
+      expect(handler).to.be.calledWith({
+        foo: 'bar',
+        baz: 'bam'
+      });
     });
 
     it('should make the marty context available in the current context', function () {


### PR DESCRIPTION
When there are pending fetches, we pass all done fetches into the
pending handler giving you the opportunity to provide default values.

Resolves #300