### PR TITLE
Fix inconsistent fetch behavoir in Chrome

### DIFF
--- a/lib/stateSource/inbuilt/http/index.js
+++ b/lib/stateSource/inbuilt/http/index.js
@@ -119,6 +119,11 @@ function requestOptions(method, source, options) {
       options.headers['Accept'] = contentType;
     }
   }
+  
+  // https://github.com/github/fetch/issues/121
+  // If this isn't set, Chrome's native fetch implementation
+  // won't send any cookies.
+  options.credentials = options.credentials || 'same-origin';
 
   return options;
 }

--- a/lib/stateSource/inbuilt/http/index.js
+++ b/lib/stateSource/inbuilt/http/index.js
@@ -119,7 +119,7 @@ function requestOptions(method, source, options) {
       options.headers['Accept'] = contentType;
     }
   }
-  
+
   // https://github.com/github/fetch/issues/121
   // If this isn't set, Chrome's native fetch implementation
   // won't send any cookies.


### PR DESCRIPTION
I noticed an issue with Chrome 42+ where cookies would not be sent when using the request API provided by the http state source. After some investigation, I found out that Chrome's implementation of fetch does send any cookies by default (https://github.com/github/fetch/issues/121). So, in order to make Chrome's behavior consistent, the credentials options must be set to "same-origin".

Let me know if you think that this could cause some undesirable effects, but I think this change will only align the behaviors of the fetch polyfill and Chrome's native fetch.