### PR TITLE
Add back old "reject on failure" behavior for HTTP

### DIFF
--- a/http/hooks/throwOnError.js
+++ b/http/hooks/throwOnError.js
@@ -1,0 +1,1 @@
+module.exports = require('../../lib/stateSource/inbuilt/http/hooks/throwOnError');

--- a/lib/stateSource/inbuilt/http/hooks/throwOnError.js
+++ b/lib/stateSource/inbuilt/http/hooks/throwOnError.js
@@ -1,0 +1,10 @@
+module.exports = {
+  id: 'throwOnError',
+  after: function (res) {
+    if (!res.ok) {
+      throw res;
+    }
+
+    return res;
+  }
+};

--- a/lib/stateSource/inbuilt/http/index.js
+++ b/lib/stateSource/inbuilt/http/index.js
@@ -69,6 +69,7 @@ class HttpStateSource extends StateSource {
   }
 }
 
+HttpStateSource.addHook(require('./hooks/throwOnError'));
 HttpStateSource.addHook(require('./hooks/parseJSON'));
 HttpStateSource.addHook(require('./hooks/stringifyJSON'));
 HttpStateSource.addHook(require('./hooks/includeCredentials'));


### PR DESCRIPTION
For martyjs/marty#308

The other changes to the test were due to some sloppiness with response codes that previously got through because we weren't rejecting on remote failures. Also, Sinon's fake server doesn't seem to work with native fetch (because it replaces XHR, which is only used by the polyfill), so need to match what's on the mock server as well.

I think the right thing to do is to just call into https://github.com/mzabriskie/axios instead of having this code in Marty, but it's probably best to have the old behavior back for the time being.