### PR TITLE
Documented the fact that a hook requires an 'id' property if you plan on using multiple hooks.

### DIFF
--- a/docs/_api/state-sources/http.md
+++ b/docs/_api/state-sources/http.md
@@ -155,12 +155,13 @@ Same as <code>request(_.extend(options, { method: 'DELETE'})</code>
 
 Hooks allows you to make changes to requests before they are sent and as well as when responses are received. This can be useful when you want to do things like automatically converting all JSON responses to immutable objects.
 
-Hooks are object literals which have 3 optional keys: ``before``, ``after`` and ``priority``. If ``before`` is present then it will be called with the request as its argument. If ``after`` is present then it will be called after the response is received with the response as its argument. Setting a priority allows you to alter in what order the hook is executed (The smaller the number, the earlier it will be executed).
+Hooks are object literals which have 4 optional keys: ``id``, ``before``, ``after`` and ``priority``. ``id`` is required if you wish to have multiple hooks registered. If ``before`` is present then it will be called with the request as its argument. If ``after`` is present then it will be called after the response is received with the response as its argument. Setting a priority allows you to alter in what order the hook is executed (The smaller the number, the earlier it will be executed).
 
 {% highlight js %}
 var Marty = require('marty');
 
 Marty.HttpStateSource.addHook({
+  id: 'SomeHook',
   priority: 1,
   before(req) {
     req.headers['Foo'] = 'bar';
@@ -179,6 +180,7 @@ Registers the hook in the pipeline
 var Marty = require('marty');
 
 Marty.HttpStateSource.addHook({
+  id: 'AnotherHook',
   priority: 1,
   before: function (req) {
     req.headers['Foo'] = 'bar';


### PR DESCRIPTION
This caused me some grief yesterday as I was wondering why it seemed like I could only have 1 hook added at a time. Stepping into addHook made it obvious why that was the case, since they are indexed by the undocumented 'id' property. Might save someone else some time if this is explicit in the docs.