### PR TITLE
HTTP methods should be upper case

### DIFF
--- a/lib/stateSource/inbuilt/http/index.js
+++ b/lib/stateSource/inbuilt/http/index.js
@@ -88,7 +88,7 @@ function requestOptions(method, source, options) {
     headers: {}
   });
 
-  options.method = method.toLowerCase();
+  options.method = method.toUpperCase();
 
   if (baseUrl) {
     var separator = '';


### PR DESCRIPTION
The Fetch spec has normalization for some methods: https://fetch.spec.whatwg.org/#concept-method-normalize, but this doesn't include `PATCH`, which against sufficiently strict webservers must be specified as uppercase.