### PR TITLE
Add warning about `createContainer` and `contextTypes`

### DIFF
--- a/docs/_guides/upgrading/09_10.md
+++ b/docs/_guides/upgrading/09_10.md
@@ -115,6 +115,8 @@ export default Marty.createContainer(User, {
 
 To update your tests, we recommend you look at our [test examples](https://github.com/martyjs/marty-test-examples) and [test utils]({% url /api/test-utils/index.html %}).
 
+**Please note**: Be aware that Marty passes the current `app` using React context. If you specify `contextTypes` on your container component, this will prevent Marty from passing `app` through to the component. To solve this, simply extend the `contextTypes` on your container component instead of setting it directly.
+
 <h3 id="isomorphism">Isomorphism</h3>
 
 [Contexts](http://martyjs.org/v/0.9.16/api/context/index.html) have been completely removed and most functions that were previously on `Marty`, e.g. [`Marty.replaceState`](http://martyjs.org/v/0.9.16/api/top-level-api/#replaceState), [`Marty.clearState`](http://martyjs.org/v/0.9.16/api/top-level-api/#clearState), [`Marty.dehydrate`](http://martyjs.org/v/0.9.16/api/top-level-api/#dehydrate) and [`Marty.rehydrate`](http://martyjs.org/v/0.9.16/api/top-level-api/#rehydrate)  have been moved to to the [application]({% url /api/application/index.html %}).


### PR DESCRIPTION
This issue had my colleague bogged down for a good couple of hours - I hope this warning will help prevent others falling into the same trap!