### PR TITLE
:memo: Make an example more sensible

### DIFF
--- a/docs/_guides/fetching-state/index.md
+++ b/docs/_guides/fetching-state/index.md
@@ -24,7 +24,7 @@ var UserStore = Marty.createStore({
         return this.state[userId];
       },
       remotely: function () {
-        return this.app.userAPI.getUser(userId)
+        return this.app.userQueries.getUser(userId)
       }
     });
   }
@@ -40,7 +40,7 @@ class UserStore extends Marty.Store {
         return this.state[userId];
       },
       remotely() {
-        return this.app.userAPI.getUser(userId)
+        return this.app.userQueries.getUser(userId)
       }
     });
   }


### PR DESCRIPTION
The first example on that guide is a little misleading because the `userAPI` should not be dispatching anything, which means nothing gets updated. This causes the call to `locally` return undefined, resulting in a "Not Found" error. May as well go with the less misleading `userQueries`.