### PR TITLE
Add a TypeScript definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ make release inc={inc} # specify what to version part to increment (major, prema
 make release-docs      # builds documentation and copies into ../marty-gh-pages
 ```
 
+## TypeScript
+
+A TypeScript definition is available at `marty.d.ts`. Please note that it requires the React definition from [DefinitelyTyped](https://github.com/borisyankov/DefinitelyTyped/blob/master/react/react.d.ts).
+
 ## Git Commit Messages
 
 * Use the present tense ("Add feature" not "Added feature")

--- a/marty.d.ts
+++ b/marty.d.ts
@@ -1,0 +1,240 @@
+declare module 'marty' {
+  import React = require('react');
+
+  module Marty {
+    interface Map<T> {
+      [name: string]: T
+    }
+
+    interface FetchOptions<T> {
+       id: string;
+       locally?: () => T;
+       remotely?: () => Promise<T>;
+       dependsOn?: FetchResult<T> | Array<FetchResult<T>>;
+       cacheError?: boolean;
+    }
+
+    interface WhenHandlers<T> {
+      done(result: T): any;
+      failed(error: any): any;
+      pending(): any;
+    }
+
+    interface When<T> {
+      (handlers: WhenHandlers<T>, context?: any): void;
+      all(fetchResult: FetchResult<any>[], handlers: WhenHandlers<Array<any>>, context?: any): void;
+      toPromise(): Promise<T>;
+    }
+
+    interface FetchResult<T> {
+      status: string;
+      failed: boolean;
+      error?: any;
+      result?: T;
+      done: boolean;
+      when: When<T>;
+      toPromise: () => Promise<T>;
+    }
+
+    interface Fetch {
+      <T>(options: FetchOptions<T>): FetchResult<T>;
+      <T>(id: string, local: () => T, remote?: () => Promise<T>): FetchResult<T>;
+
+      done<T>(result: T, id: string, store: Store<any>): FetchResult<T>;
+      pending(id: string, store: Store<any>): FetchResult<any>;
+      failed(error: any, id: string, store: Store<any>): FetchResult<any>;
+      notFound(id: string, store: Store<any>): FetchResult<any>;
+    }
+
+    type MartyInstance = Store<any> | ActionCreators | Queries | StateSource;
+
+    type MartyType = { new (...args: any[]): MartyInstance };
+
+    interface RegisterMap {
+      [id: string]: RegisterMap | MartyType;
+    }
+
+    class Application {
+      register(map: RegisterMap): void;
+      register(id: string, instance: MartyType): void;
+    }
+
+    class ApplicationContainer extends React.Component<{ app: Application }, {}> {}
+
+    class Store<S> {
+      state: S;
+      handlers: any;
+      dispatchToken: string;
+
+      app: any;
+
+      constructor(options: any);
+      setState(nextState: S): void;
+      replaceState(nextState: S): void;
+      addChangeListener(callback: (state: S, store: Store<S>) => any, context: any): void;
+      hasChanged(): void;
+      fetch: Fetch;
+      hasAlreadyFetched(id: string): boolean;
+      waitFor(stores: Array<Store<any>>): void;
+    }
+
+    class ActionCreators {
+      id: string;
+      app: Marty;
+      dispatch(type: string, ...data: any[]): void;
+    }
+
+    class Queries extends DispatchCoordinator {
+      id: string;
+      app: Marty;
+      dispatch(type: string, ...data: any[]): void;
+    }
+
+    type ContainerConfigFetch = Map<Function> | (() => Map<Function>);
+
+    interface ContainerConfig {
+      listenTo: string | Array<string>;
+      fetch?: ContainerConfigFetch;
+      done?: (props: any) => React.ReactElement<any>;
+      pending?: () => React.ReactElement<any>;
+      failed?: (errors: any[]) => React.ReactElement<any>;
+    }
+
+    function createContainer(component: React.ComponentClass<any>, config?: ContainerConfig): React.ClassicComponentClass<{}>;
+
+    class StateSource {
+      id: string;
+      type: string;
+      mixins: Array<any>;
+
+      app: any;
+    }
+
+    class CookieStateSource extends StateSource {
+      get(key: string): any;
+      set(key: string, value: any): boolean;
+      expire(key: string): boolean;
+    }
+
+    interface RequestOptions {
+      url: string;
+      method?: string;
+      headers?: Map<string>;
+      body?: string | Object;
+      contentType?: string;
+      dataType?: string;
+    }
+
+    interface HttpFetch {
+      text(): Promise<string>;
+      json(): Promise<string>;
+      headers: {
+        get(key: string): string;
+      }
+      status: number;
+      statusText: string;
+    }
+
+    interface HookOptions {
+      id: string;
+      priority?: number;
+      before?: (req: any) => any;
+      after?: (res: any) => any;
+    }
+
+    class HttpStateSource extends StateSource {
+      baseUrl: string;
+      request(options: RequestOptions): Promise<HttpFetch>;
+      get(url: string): Promise<HttpFetch>;
+      get(options: RequestOptions): Promise<HttpFetch>;
+      post(url: string): Promise<HttpFetch>;
+      post(options: RequestOptions): Promise<HttpFetch>;
+      put(url: string): Promise<HttpFetch>;
+      put(options: RequestOptions): Promise<HttpFetch>;
+      delete(url: string): Promise<HttpFetch>;
+      delete(options: RequestOptions): Promise<HttpFetch>;
+
+      static addHook(options: HookOptions): void;
+      static removeHook(options: HookOptions): void;
+    }
+
+    class JSONStorageStateSource extends StateSource {
+      storage: any;
+      namespace: string;
+
+      get(key: string): any;
+      set(key: string, value: any): void;
+    }
+
+    class LocalStorageStateSource extends JSONStorageStateSource {}
+
+    class SessionStorageStateSource extends JSONStorageStateSource {}
+
+    interface LocationInformation {
+      url: string;
+      path: string;
+      hostname: string;
+      query: Map<string>;
+      protocol: string;
+    }
+
+    class LocationStateSource extends StateSource {
+      getLocation(): LocationInformation
+    }
+
+    function get(type: string, id: string): any;
+
+    function getAll(type: string): any[];
+
+    function getDefault(type: string, id: string): any;
+
+    function getAllDefaults(type: string): any[];
+
+    function resolve(type: string, id: string, options?: Object): any;
+
+    interface Dispatcher {
+      id: string;
+      isDefault: boolean;
+      dispatchAction(options: Object): any;
+      onActionDispatched(callback: (action: any) => any, context?: any): void;
+    }
+
+    var dispatcher: Dispatcher;
+
+    interface ConstantsOption {
+      [key: string]: string[] | ConstantsOption;
+    }
+
+    function createConstants(constants: string[] | ConstantsOption): any;
+
+    interface Warnings {
+      without(warningsToDisable: string[], callback: () => any, context?: any): void;
+      invokeConstant: boolean;
+      reservedFunction: boolean;
+      cannotFindContext: boolean;
+      classDoesNotHaveAnId: boolean;
+      stateIsNullOrUndefined: boolean;
+      callingResolverOnServer: boolean;
+      stateSourceAlreadyExists: boolean;
+      superNotCalledWithOptions: boolean;
+      promiseNotReturnedFromRemotely: boolean;
+      contextNotPassedInToConstructor: boolean;
+    }
+
+    var warnings: Warnings;
+
+    function createInstance(): typeof Marty;
+
+    function dispose(): void;
+
+    var version: string;
+
+    var isServer: boolean;
+
+    var isBrowser: boolean;
+  }
+
+  import M = Marty;
+
+  export = M;
+}

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
       "babelify"
     ]
   },
-  "homepage": "https://martyjs.org"
+  "homepage": "https://martyjs.org",
+  "typescript": {
+    "definition": "marty.d.ts"
+  }
 }


### PR DESCRIPTION
Thanks for taking a look at this PR! I've been using Marty with TypeScript for a little while and had to write out my own type definition for it. This file was originally based on `0.9`, but I updated it according to the change log and my application to `0.10`. It's possible there's still some parts missing.

Now, for some caveats of this. Currently the third-party definition system for TypeScript is fragmented with most people trying to publish to and consume a centralised repository. I'm currently working on the next version of TSD which will solve this issue at its core. For now, people will need to know (as mentioned in the README) that this definition requires React and Flux. If you wish to avoid this, you can change the types to `any` but that will ignore type information around those interfaces.

Feel free to make a note of any issues you notice in the definition :smile: I'll be sure to keep it up to date for you and, when the next TSD version comes out, fix the caveats that exist. When the new version is released, I'll come back to this and refactor the definition into `marty-lib` and consume inside this library.