### PR TITLE
:arrow_up: Update for React v0.14 (sorry!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-### Marty v10.0 will be the last major release. Use [Alt](http://alt.js.org) or [Redux](https://github.com/gaearon/redux) instead. [More info](http://martyjs.org/blog/2015/08/02/marty-last.html)
+### Marty is no longer actively maintained. Use [Alt](http://alt.js.org) or [Redux](https://github.com/gaearon/redux) instead. [More info](http://martyjs.org/blog/2015/08/02/marty-last.html).
 
 
 [Marty](http://martyjs.org) is a Javascript library for state management in React applications. It is an implementation of the [Flux architecture](http://facebook.github.io/flux/docs/overview.html).

--- a/marty.js
+++ b/marty.js
@@ -8,7 +8,7 @@ require('es6-promise').polyfill();
 require('isomorphic-fetch');
 
 var Marty = require('marty-lib/modules/core/marty');
-var marty = new Marty('0.10.5', react());
+var marty = new Marty('0.10.5', react(), reactDomServer());
 
 marty.use(require('marty-lib/modules/core'));
 marty.use(require('marty-lib/modules/constants'));
@@ -42,4 +42,25 @@ function react() {
   }
 
   throw new Error('Could not find React');
+}
+
+function reactDomServer() {
+  try {
+    return module.parent.require("react-dom/server");
+  } catch (e) {
+    try {
+      return require("react-dom/server");
+    } catch (e) {
+      if (windowDefined) {
+        if (!window.ReactDOMServer) {
+          // Don't require ReactDOMServer in browser.
+          return {};
+        }
+
+        return window.ReactDOMServer;
+      }
+    }
+  }
+
+  throw new Error('Could not find ReactDOMServer');
 }

--- a/package.json
+++ b/package.json
@@ -21,19 +21,21 @@
   "dependencies": {
     "es6-promise": "^2.0.0",
     "isomorphic-fetch": "^2.1.0",
-    "marty-lib": "^0.10.8"
+    "marty-lib": "^0.11.0"
   },
   "devDependencies": {
     "babel": "^5.0.0",
     "babelify": "^6.0.0",
     "browserify": "^10.0.0",
     "bundle-collapser": "^1.2.0",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "semver": "^4.2.0",
     "uglify-js": "^2.4.23"
   },
   "peerDependencies": {
-    "react": "0.13.x"
+    "react": "0.14.x",
+    "react-dom": "0.14.x"
   },
   "author": "James Hollingworth",
   "license": "MIT",


### PR DESCRIPTION
I'm really sorry to be making this change, but I have some old stuff that I haven't had the chance to migrate off Marty yet, because my next update is going to be with GraphQL/Relay instead, and I haven't had time to do that yet.